### PR TITLE
add wandb hook and use it in tutorial 00

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ datasets
 generated
 image_bin
 release
+
+# wandb
+wandb/

--- a/src/autoprognosis/hooks/__init__.py
+++ b/src/autoprognosis/hooks/__init__.py
@@ -1,3 +1,4 @@
 # autoprognosis relative
-from .base import Hooks  # noqa: F401
-from .default import DefaultHooks  # noqa: F401
+from .base import Hook, Hooks  # noqa: F401
+from .default import DefaultHooks, DefaultHook  # noqa: F401
+from .wandb import WandbHook  # noqa: F401

--- a/src/autoprognosis/hooks/base.py
+++ b/src/autoprognosis/hooks/base.py
@@ -1,10 +1,10 @@
 # stdlib
 from abc import ABCMeta, abstractmethod
-from typing import Any
+from typing import Any, List
 
 
-class Hooks(metaclass=ABCMeta):
-    """AutoML hooks interface.
+class Hook(metaclass=ABCMeta):
+    """AutoML hook interface.
 
     Methods:
         - cancel: True/False if to stop the current AutoML search.
@@ -25,3 +25,32 @@ class Hooks(metaclass=ABCMeta):
     @abstractmethod
     def finish(self) -> None:
         ...
+
+
+class Hooks:
+    """AutoML hooks container.
+
+    Methods:
+        - cancel: True/False if to stop the current AutoML search.
+        - heartbeat: Metrics/logs sink from the AutoML search
+
+    """
+    def __init__(self, hooks: List[Hook]) -> None:
+        self.hooks = hooks
+        
+    def append(self, hook: Hook) -> "Hooks":
+        self.hooks.append(hook)
+        return self
+
+    def cancel(self) -> bool:
+        return any(hook.cancel() for hook in self.hooks)
+
+    def heartbeat(
+        self, topic: str, subtopic: str, event_type: str, **kwargs: Any
+    ) -> None:
+        for hook in self.hooks:
+            hook.heartbeat(topic, subtopic, event_type, **kwargs)
+
+    def finish(self) -> None:
+        for hook in self.hooks:
+            hook.finish()

--- a/src/autoprognosis/hooks/base.py
+++ b/src/autoprognosis/hooks/base.py
@@ -9,7 +9,7 @@ class Hook(metaclass=ABCMeta):
     Methods:
         - cancel: True/False if to stop the current AutoML search.
         - heartbeat: Metrics/logs sink from the AutoML search
-
+        - finish: executes after the AutoML search is finished.
     """
 
     @abstractmethod
@@ -27,30 +27,37 @@ class Hook(metaclass=ABCMeta):
         ...
 
 
-class Hooks:
+class Hooks(list):
     """AutoML hooks container.
 
     Methods:
+        - append: Add a hook to the container.
+        - extend: Add multiple hooks to the container.
         - cancel: True/False if to stop the current AutoML search.
         - heartbeat: Metrics/logs sink from the AutoML search
-
+        - finish: executes after the AutoML search is finished.
     """
-    def __init__(self, hooks: List[Hook]) -> None:
-        self.hooks = hooks
-        
+
     def append(self, hook: Hook) -> "Hooks":
-        self.hooks.append(hook)
+        super().append(hook)
+        return self
+
+    def extend(self, hooks: List[Hook]) -> "Hooks":
+        super().extend(hooks)
         return self
 
     def cancel(self) -> bool:
-        return any(hook.cancel() for hook in self.hooks)
+        return any(hook.cancel() for hook in self)
 
     def heartbeat(
         self, topic: str, subtopic: str, event_type: str, **kwargs: Any
     ) -> None:
-        for hook in self.hooks:
+        for hook in self:
             hook.heartbeat(topic, subtopic, event_type, **kwargs)
 
     def finish(self) -> None:
-        for hook in self.hooks:
+        for hook in self:
             hook.finish()
+
+    def __repr__(self) -> str:
+        return f"Hooks({super().__repr__()})"

--- a/src/autoprognosis/hooks/default.py
+++ b/src/autoprognosis/hooks/default.py
@@ -5,10 +5,10 @@ from typing import Any
 import autoprognosis.logger as log
 
 # autoprognosis relative
-from .base import Hooks
+from .base import Hook, Hooks
 
 
-class DefaultHooks(Hooks):
+class DefaultHook(Hook):
     def cancel(self) -> bool:
         return False
 
@@ -19,3 +19,8 @@ class DefaultHooks(Hooks):
 
     def finish(self) -> None:
         pass
+
+
+class DefaultHooks(Hooks):
+    def __init__(self) -> None:
+        super().__init__([DefaultHook()])

--- a/src/autoprognosis/hooks/wandb.py
+++ b/src/autoprognosis/hooks/wandb.py
@@ -9,7 +9,7 @@ from .base import Hook
 
 
 class WandbHook(Hook):
-    def __init__(self, **config: Any):
+    def __init__(self, **config: Any) -> None:
         super().__init__()
         self.wandb_config = config
 

--- a/src/autoprognosis/hooks/wandb.py
+++ b/src/autoprognosis/hooks/wandb.py
@@ -1,10 +1,8 @@
 # stdlib
-from typing import Any, Dict
+from typing import Any
 
+# third party
 import wandb
-
-# autoprognosis absolute
-import autoprognosis.logger as log
 
 # autoprognosis relative
 from .base import Hook
@@ -23,16 +21,15 @@ class WandbHook(Hook):
     ) -> None:
         if wandb.run is None:
             wandb.init(
-                project='autoprognosis',
+                project="autoprognosis",
                 group=topic,
-                name=f'{topic}-{subtopic}',
+                name=f"{topic}-{subtopic}",
                 job_type=event_type,
-                **self.wandb_config
+                **self.wandb_config,
             )
-        table = {k: kwargs.pop(k) for k in list(kwargs)
-                 if isinstance(kwargs[k], str)}
+        table = {k: kwargs.pop(k) for k in list(kwargs) if isinstance(kwargs[k], str)}
         table = wandb.Table(columns=list(table), data=[list(table.values())])
-        kwargs['text_table'] = table
+        kwargs["text_table"] = table
         wandb.log(kwargs)
 
     def finish(self) -> None:

--- a/src/autoprognosis/hooks/wandb.py
+++ b/src/autoprognosis/hooks/wandb.py
@@ -1,0 +1,39 @@
+# stdlib
+from typing import Any, Dict
+
+import wandb
+
+# autoprognosis absolute
+import autoprognosis.logger as log
+
+# autoprognosis relative
+from .base import Hook
+
+
+class WandbHook(Hook):
+    def __init__(self, **config: Any):
+        super().__init__()
+        self.wandb_config = config
+
+    def cancel(self) -> bool:
+        return False
+
+    def heartbeat(
+        self, topic: str, subtopic: str, event_type: str, **kwargs: Any
+    ) -> None:
+        if wandb.run is None:
+            wandb.init(
+                project='autoprognosis',
+                group=topic,
+                name=f'{topic}-{subtopic}',
+                job_type=event_type,
+                **self.wandb_config
+            )
+        table = {k: kwargs.pop(k) for k in list(kwargs)
+                 if isinstance(kwargs[k], str)}
+        table = wandb.Table(columns=list(table), data=[list(table.values())])
+        kwargs['text_table'] = table
+        wandb.log(kwargs)
+
+    def finish(self) -> None:
+        pass

--- a/tutorials/automl/tutorial_00_classification_study.ipynb
+++ b/tutorials/automl/tutorial_00_classification_study.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "90163d91",
    "metadata": {},
    "outputs": [],
@@ -49,13 +49,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "822b4467",
    "metadata": {},
    "outputs": [],
    "source": [
     "# autoprognosis absolute\n",
-    "from autoprognosis.studies.classifiers import ClassifierStudy"
+    "from autoprognosis.studies.classifiers import ClassifierStudy\n",
+    "from autoprognosis.hooks import DefaultHooks, WandbHook"
    ]
   },
   {
@@ -72,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f3141611",
    "metadata": {},
    "outputs": [],
@@ -100,10 +101,112 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "49bea04a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"imputer\": {\n",
+      "    \"default\": [\n",
+      "      \"EM\",\n",
+      "      \"gain\",\n",
+      "      \"hyperimpute\",\n",
+      "      \"ice\",\n",
+      "      \"mean\",\n",
+      "      \"median\",\n",
+      "      \"mice\",\n",
+      "      \"missforest\",\n",
+      "      \"most_frequent\",\n",
+      "      \"nop\",\n",
+      "      \"sinkhorn\",\n",
+      "      \"softimpute\"\n",
+      "    ]\n",
+      "  },\n",
+      "  \"prediction\": {\n",
+      "    \"classifier\": [\n",
+      "      \"adaboost\",\n",
+      "      \"bagging\",\n",
+      "      \"bernoulli_naive_bayes\",\n",
+      "      \"catboost\",\n",
+      "      \"decision_trees\",\n",
+      "      \"extra_tree_classifier\",\n",
+      "      \"gaussian_naive_bayes\",\n",
+      "      \"gaussian_process\",\n",
+      "      \"gradient_boosting\",\n",
+      "      \"hist_gradient_boosting\",\n",
+      "      \"knn\",\n",
+      "      \"lda\",\n",
+      "      \"lgbm\",\n",
+      "      \"linear_svm\",\n",
+      "      \"logistic_regression\",\n",
+      "      \"multinomial_naive_bayes\",\n",
+      "      \"neural_nets\",\n",
+      "      \"perceptron\",\n",
+      "      \"qda\",\n",
+      "      \"random_forest\",\n",
+      "      \"ridge_classifier\",\n",
+      "      \"tabnet\",\n",
+      "      \"xgboost\"\n",
+      "    ],\n",
+      "    \"regression\": [\n",
+      "      \"bayesian_ridge\",\n",
+      "      \"catboost_regressor\",\n",
+      "      \"kneighbors_regressor\",\n",
+      "      \"linear_regression\",\n",
+      "      \"mlp_regressor\",\n",
+      "      \"neural_nets_regression\",\n",
+      "      \"random_forest_regressor\",\n",
+      "      \"tabnet_regressor\",\n",
+      "      \"xgboost_regressor\"\n",
+      "    ],\n",
+      "    \"risk_estimation\": [\n",
+      "      \"coxnet\",\n",
+      "      \"cox_ph\",\n",
+      "      \"deephit\",\n",
+      "      \"loglogistic_aft\",\n",
+      "      \"lognormal_aft\",\n",
+      "      \"survival_xgboost\",\n",
+      "      \"weibull_aft\"\n",
+      "    ]\n",
+      "  },\n",
+      "  \"explainer\": {\n",
+      "    \"default\": [\n",
+      "      \"invase\",\n",
+      "      \"kernel_shap\",\n",
+      "      \"lime\",\n",
+      "      \"risk_effect_size\",\n",
+      "      \"shap_permutation_sampler\",\n",
+      "      \"symbolic_pursuit\"\n",
+      "    ]\n",
+      "  },\n",
+      "  \"preprocessor\": {\n",
+      "    \"feature_scaling\": [\n",
+      "      \"feature_normalizer\",\n",
+      "      \"maxabs_scaler\",\n",
+      "      \"minmax_scaler\",\n",
+      "      \"nop\",\n",
+      "      \"normal_transform\",\n",
+      "      \"scaler\",\n",
+      "      \"uniform_transform\"\n",
+      "    ],\n",
+      "    \"dimensionality_reduction\": [\n",
+      "      \"data_cleanup\",\n",
+      "      \"fast_ica\",\n",
+      "      \"feature_agglomeration\",\n",
+      "      \"gauss_projection\",\n",
+      "      \"nop\",\n",
+      "      \"pca\",\n",
+      "      \"variance_threshold\"\n",
+      "    ]\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "# List the available plugins\n",
     "\n",
@@ -123,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "c3061090",
    "metadata": {},
    "outputs": [],
@@ -137,7 +240,7 @@
     "    study_name=study_name,\n",
     "    dataset=df,  # pandas DataFrame\n",
     "    target=\"target\",  # the label column in the dataset\n",
-    "    num_iter=2,  # DELETE THIS LINE FOR BETTER RESULTS. how many trials to do for each candidate. Default: 50\n",
+    "    num_iter=10,  # DELETE THIS LINE FOR BETTER RESULTS. how many trials to do for each candidate. Default: 50\n",
     "    num_study_iter=1,  # DELETE THIS LINE FOR BETTER RESULTS. how many outer iterations to do. Default: 5\n",
     "    classifiers=[\n",
     "        \"logistic_regression\",\n",
@@ -145,6 +248,7 @@
     "        \"qda\",\n",
     "    ],  # DELETE THIS LINE FOR BETTER RESULTS.\n",
     "    workspace=workspace,\n",
+    "    hooks=DefaultHooks().append(WandbHook()),\n",
     ")"
    ]
   },
@@ -158,20 +262,85 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "b30a99bf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>#sk-container-id-2 {color: black;background-color: white;}#sk-container-id-2 pre{padding: 0;}#sk-container-id-2 div.sk-toggleable {background-color: white;}#sk-container-id-2 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-2 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-2 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-2 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-2 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-2 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-2 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-2 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-2 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-2 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-2 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-2 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-2 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-2 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-2 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-2 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-2 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-2 div.sk-item {position: relative;z-index: 1;}#sk-container-id-2 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-2 div.sk-item::before, #sk-container-id-2 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-2 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-2 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-2 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-2 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-2 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-2 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-2 div.sk-label-container {text-align: center;}#sk-container-id-2 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-2 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-2\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>WeightedEnsemble(models=[&lt;autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_lda object at 0x000002BE32366140&gt;,\n",
+       "                         &lt;autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_qda object at 0x000002BE32398250&gt;,\n",
+       "                         &lt;autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_logistic_regression object at 0x000002BE32367A90&gt;],\n",
+       "                 weights=[0.2352941175086505, 0.470588235017301,\n",
+       "                          0.29411764688581316])</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-2\" type=\"checkbox\" checked><label for=\"sk-estimator-id-2\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">WeightedEnsemble</label><div class=\"sk-toggleable__content\"><pre>WeightedEnsemble(models=[&lt;autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_lda object at 0x000002BE32366140&gt;,\n",
+       "                         &lt;autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_qda object at 0x000002BE32398250&gt;,\n",
+       "                         &lt;autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_logistic_regression object at 0x000002BE32367A90&gt;],\n",
+       "                 weights=[0.2352941175086505, 0.470588235017301,\n",
+       "                          0.29411764688581316])</pre></div></div></div></div></div>"
+      ],
+      "text/plain": [
+       "WeightedEnsemble(models=[<autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_lda object at 0x000002BE32366140>,\n",
+       "                         <autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_qda object at 0x000002BE32398250>,\n",
+       "                         <autoprognosis.plugins.pipeline.fast_ica_feature_normalizer_data_cleanup_logistic_regression object at 0x000002BE32367A90>],\n",
+       "                 weights=[0.2352941175086505, 0.470588235017301,\n",
+       "                          0.29411764688581316])"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "study.run()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "399fd86c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model 0.1874999998828125 * (pca->maxabs_scaler->data_cleanup->lda) + 0.624999999609375 * (data_cleanup->logistic_regression) + 0.1874999998828125 * (pca->maxabs_scaler->data_cleanup->qda) \n",
+      "Score: \n",
+      "{'raw': {'accuracy': (0.9525666016894087, 0.00831882156526754),\n",
+      "         'aucprc': (0.9923907993530281, 0.004491214387734272),\n",
+      "         'aucroc': (0.9892418939406747, 0.0047820586713733714),\n",
+      "         'f1_score_macro': (0.9487085349863671, 0.008984798950139166),\n",
+      "         'f1_score_micro': (0.9525666016894087, 0.00831882156526754),\n",
+      "         'f1_score_weighted': (0.9522847627675723, 0.008405935546129645),\n",
+      "         'kappa': (0.8974702024409966, 0.017942781976667134),\n",
+      "         'kappa_quadratic': (0.8974702024409966, 0.017942781976667134),\n",
+      "         'mcc': (0.8984245080218889, 0.017605200083484915),\n",
+      "         'precision_macro': (0.954473104175413, 0.008611940788115212),\n",
+      "         'precision_micro': (0.9525666016894087, 0.00831882156526754),\n",
+      "         'precision_weighted': (0.9529458849052901, 0.008173645387861282),\n",
+      "         'recall_macro': (0.9440269065372627, 0.009842702960455342),\n",
+      "         'recall_micro': (0.9525666016894087, 0.00831882156526754),\n",
+      "         'recall_weighted': (0.9525666016894087, 0.00831882156526754)},\n",
+      " 'str': {'accuracy': '0.953 +/- 0.008',\n",
+      "         'aucprc': '0.992 +/- 0.004',\n",
+      "         'aucroc': '0.989 +/- 0.005',\n",
+      "         'f1_score_macro': '0.949 +/- 0.009',\n",
+      "         'f1_score_micro': '0.953 +/- 0.008',\n",
+      "         'f1_score_weighted': '0.952 +/- 0.008',\n",
+      "         'kappa': '0.897 +/- 0.018',\n",
+      "         'kappa_quadratic': '0.897 +/- 0.018',\n",
+      "         'mcc': '0.898 +/- 0.018',\n",
+      "         'precision_macro': '0.954 +/- 0.009',\n",
+      "         'precision_micro': '0.953 +/- 0.008',\n",
+      "         'precision_weighted': '0.953 +/- 0.008',\n",
+      "         'recall_macro': '0.944 +/- 0.01',\n",
+      "         'recall_micro': '0.953 +/- 0.008',\n",
+      "         'recall_weighted': '0.953 +/- 0.008'}}\n"
+     ]
+    }
+   ],
    "source": [
     "# stdlib\n",
     "import pprint\n",
@@ -202,10 +371,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "2230c4d2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.1874999998828125 * (pca->maxabs_scaler->data_cleanup->lda) + 0.624999999609375 * (data_cleanup->logistic_regression) + 0.1874999998828125 * (pca->maxabs_scaler->data_cleanup->qda)\n"
+     ]
+    }
+   ],
    "source": [
     "# autoprognosis absolute\n",
     "from autoprognosis.utils.serialization import load_from_file, save_to_file\n",
@@ -261,7 +438,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
I added some changes to the "hooks" folder, including adding a `Hook` class, renaming `DefaultHooks` to `DefaultHook`, and adding `WandbHook`. The `Hooks` object now becomes a container of `Hook`s, initialized by `Hooks([<Hook>, ...])`, and adding a hook can be easily done by `<Hooks>.append(<Hook>)`.

## How has this been tested?
- I tested it by adding a `WandbHook` in the hooks of a classification study in Tutorial 0. The metrics were successfully logged in my wandb project.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
